### PR TITLE
feat: load toolgate.config.local.ts alongside shared config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 dist/
+toolgate.config.local.ts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ Use Bun exclusively — not Node.js, npm, yarn, or pnpm. Bun auto-loads `.env`.
 - **`types.ts`** — `ToolCall`, `CallContext`, `VerdictResult`, `Middleware`, `Policy` type definitions
 - **`verdicts.ts`** — Symbol-based verdict system: `ALLOW`, `DENY`, `NEXT` with helpers `allow()`, `deny(reason?)`, `next()`
 - **`policy.ts`** — `definePolicy()` and `runPolicy()` — sequential policy chain, returns first non-NEXT verdict
-- **`config.ts`** — Loads project config (`./toolgate.config.ts` or `./.claude/toolgate.config.ts`) then built-in policies, concatenates policy arrays
+- **`config.ts`** — Walks from cwd up to `$HOME` collecting configs. At each level, loads `toolgate.config.local.ts` (personal, gitignored) before `toolgate.config.ts` (committed, team-shared); prefers `./` over `./.claude/`. Built-in policies are appended last.
 - **`runner.ts`** — Bridges Claude Code hook stdin/stdout protocol to the policy engine
 - **`cli.ts`** — Subcommands: `run` (hook handler), `init` (setup), `test` (dry-run), `list` (show loaded policies)
 - **`list-cmd.ts`** — Lists all loaded policies with names and descriptions

--- a/README.md
+++ b/README.md
@@ -61,7 +61,16 @@ This registers a `PreToolUse` hook in `~/.claude/settings.json`. Toolgate ships 
 
 ## Configuration
 
-Optionally add project-specific policies in `toolgate.config.ts` (project root or `.claude/`). These run **before** built-in policies:
+Toolgate walks from the current directory up to `$HOME` and loads every config it finds along the way. At each level it checks two filenames, in this order:
+
+1. `toolgate.config.local.ts` — **personal, gitignored.** For policies specific to your machine or setup that you don't want to commit.
+2. `toolgate.config.ts` — **shared, committed.** For policies the whole team uses.
+
+Both may live at the directory root or inside `.claude/`. Personal configs are evaluated before shared ones, and inner directories are evaluated before outer ones, so the most specific/personal policy wins. Built-in policies always run last.
+
+`toolgate init --project` creates the shared config and adds `toolgate.config.local.ts` to your project's `.gitignore`.
+
+Example shared config:
 
 ```ts
 import { definePolicy, deny, next } from "toolgate";
@@ -80,7 +89,7 @@ export default definePolicy([
 ]);
 ```
 
-Project policies run first, then built-in. The first non-`next()` verdict wins.
+Project policies run first (personal before shared), then built-in. The first non-`next()` verdict wins.
 
 ## Writing Policies
 

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -18,14 +18,14 @@ describe('findConfigInDir', () => {
   it('finds toolgate.config.ts in dir', async () => {
     const configPath = join(tempDir, 'toolgate.config.ts')
     await writeFile(configPath, 'export default []')
-    expect(findConfigInDir(tempDir)).toBe(configPath)
+    expect(findConfigInDir(tempDir)).toEqual([configPath])
   })
 
   it('finds .claude/toolgate.config.ts in dir', async () => {
     await mkdir(join(tempDir, '.claude'), { recursive: true })
     const configPath = join(tempDir, '.claude', 'toolgate.config.ts')
     await writeFile(configPath, 'export default []')
-    expect(findConfigInDir(tempDir)).toBe(configPath)
+    expect(findConfigInDir(tempDir)).toEqual([configPath])
   })
 
   it('prefers root config over .claude/ config', async () => {
@@ -34,11 +34,41 @@ describe('findConfigInDir', () => {
     const claudeConfig = join(tempDir, '.claude', 'toolgate.config.ts')
     await writeFile(rootConfig, 'export default []')
     await writeFile(claudeConfig, 'export default []')
-    expect(findConfigInDir(tempDir)).toBe(rootConfig)
+    expect(findConfigInDir(tempDir)).toEqual([rootConfig])
   })
 
-  it('returns null when no config found', () => {
-    expect(findConfigInDir(tempDir)).toBeNull()
+  it('returns empty array when no config found', () => {
+    expect(findConfigInDir(tempDir)).toEqual([])
+  })
+
+  it('returns local config before shared config', async () => {
+    const sharedConfig = join(tempDir, 'toolgate.config.ts')
+    const localConfig = join(tempDir, 'toolgate.config.local.ts')
+    await writeFile(sharedConfig, 'export default []')
+    await writeFile(localConfig, 'export default []')
+    expect(findConfigInDir(tempDir)).toEqual([localConfig, sharedConfig])
+  })
+
+  it('finds local config alone when no shared config exists', async () => {
+    const localConfig = join(tempDir, 'toolgate.config.local.ts')
+    await writeFile(localConfig, 'export default []')
+    expect(findConfigInDir(tempDir)).toEqual([localConfig])
+  })
+
+  it('finds local config in .claude/ when no root local exists', async () => {
+    await mkdir(join(tempDir, '.claude'), { recursive: true })
+    const claudeLocal = join(tempDir, '.claude', 'toolgate.config.local.ts')
+    await writeFile(claudeLocal, 'export default []')
+    expect(findConfigInDir(tempDir)).toEqual([claudeLocal])
+  })
+
+  it('prefers root local over .claude/ local', async () => {
+    await mkdir(join(tempDir, '.claude'), { recursive: true })
+    const rootLocal = join(tempDir, 'toolgate.config.local.ts')
+    const claudeLocal = join(tempDir, '.claude', 'toolgate.config.local.ts')
+    await writeFile(rootLocal, 'export default []')
+    await writeFile(claudeLocal, 'export default []')
+    expect(findConfigInDir(tempDir)).toEqual([rootLocal])
   })
 })
 
@@ -84,6 +114,27 @@ describe('findAllConfigs', () => {
     await mkdir(child, { recursive: true })
 
     expect(findAllConfigs(child)).toEqual([parentConfig])
+  })
+
+  it('orders local before shared at each level when walking up', async () => {
+    const parentShared = join(tempDir, 'toolgate.config.ts')
+    const parentLocal = join(tempDir, 'toolgate.config.local.ts')
+    await writeFile(parentShared, 'export default []')
+    await writeFile(parentLocal, 'export default []')
+
+    const child = join(tempDir, 'child')
+    await mkdir(child)
+    const childShared = join(child, 'toolgate.config.ts')
+    const childLocal = join(child, 'toolgate.config.local.ts')
+    await writeFile(childShared, 'export default []')
+    await writeFile(childLocal, 'export default []')
+
+    expect(findAllConfigs(child)).toEqual([
+      childLocal,
+      childShared,
+      parentLocal,
+      parentShared,
+    ])
   })
 })
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,20 +5,33 @@ import type { Policy } from './types'
 import { builtinPolicies } from '../policies'
 
 const CONFIG_FILENAME = 'toolgate.config.ts'
+const LOCAL_CONFIG_FILENAME = 'toolgate.config.local.ts'
 
-export function findConfigInDir(dir: string): string | null {
-  const rootConfig = join(dir, CONFIG_FILENAME)
-  if (existsSync(rootConfig)) return rootConfig
+/**
+ * Find configs in a single directory. Returns paths in priority order:
+ * local (personal, gitignored) before shared (committed). Within each
+ * variant, prefers `./` over `./.claude/`.
+ */
+export function findConfigInDir(dir: string): string[] {
+  const configs: string[] = []
 
-  const claudeConfig = join(dir, '.claude', CONFIG_FILENAME)
-  if (existsSync(claudeConfig)) return claudeConfig
+  const rootLocal = join(dir, LOCAL_CONFIG_FILENAME)
+  const claudeLocal = join(dir, '.claude', LOCAL_CONFIG_FILENAME)
+  if (existsSync(rootLocal)) configs.push(rootLocal)
+  else if (existsSync(claudeLocal)) configs.push(claudeLocal)
 
-  return null
+  const rootShared = join(dir, CONFIG_FILENAME)
+  const claudeShared = join(dir, '.claude', CONFIG_FILENAME)
+  if (existsSync(rootShared)) configs.push(rootShared)
+  else if (existsSync(claudeShared)) configs.push(claudeShared)
+
+  return configs
 }
 
 /**
  * Walk from cwd up to $HOME, collecting all toolgate configs.
- * Returns innermost first (most specific takes priority).
+ * Returns innermost first (most specific takes priority); within a
+ * directory, local configs come before shared ones.
  */
 export function findAllConfigs(cwd: string): string[] {
   const home = homedir()
@@ -26,8 +39,7 @@ export function findAllConfigs(cwd: string): string[] {
   let dir = cwd
 
   while (true) {
-    const config = findConfigInDir(dir)
-    if (config) configs.push(config)
+    configs.push(...findConfigInDir(dir))
 
     if (dir === home || dir === '/') break
     const parent = dirname(dir)

--- a/src/init.ts
+++ b/src/init.ts
@@ -61,15 +61,36 @@ export async function initGlobal(): Promise<void> {
   }
 }
 
+const LOCAL_CONFIG_GITIGNORE_ENTRY = 'toolgate.config.local.ts'
+
+async function ensureLocalConfigGitignored(cwd: string): Promise<void> {
+  // Only touch .gitignore inside a git repo.
+  if (!existsSync(join(cwd, '.git'))) return
+
+  const gitignorePath = join(cwd, '.gitignore')
+  let contents = ''
+  if (existsSync(gitignorePath)) {
+    contents = await readFile(gitignorePath, 'utf-8')
+    const lines = contents.split('\n').map(l => l.trim())
+    if (lines.includes(LOCAL_CONFIG_GITIGNORE_ENTRY)) return
+  }
+
+  const needsNewline = contents.length > 0 && !contents.endsWith('\n')
+  const addition = (needsNewline ? '\n' : '') + LOCAL_CONFIG_GITIGNORE_ENTRY + '\n'
+  await writeFile(gitignorePath, contents + addition)
+  console.log(`Added ${LOCAL_CONFIG_GITIGNORE_ENTRY} to ${gitignorePath}`)
+}
+
 export async function initProject(cwd: string): Promise<void> {
   const configPath = join(cwd, 'toolgate.config.ts')
 
   if (existsSync(configPath)) {
     console.log(`Project config already exists: ${configPath}`)
-    return
+  } else {
+    const srcPath = findToolgateSrc()
+    await writeFile(configPath, projectTemplate(srcPath))
+    console.log(`Created project config: ${configPath}`)
   }
 
-  const srcPath = findToolgateSrc()
-  await writeFile(configPath, projectTemplate(srcPath))
-  console.log(`Created project config: ${configPath}`)
+  await ensureLocalConfigGitignored(cwd)
 }


### PR DESCRIPTION
## Summary

- Adds support for `toolgate.config.local.ts` — a personal, gitignored config variant loaded alongside the committed `toolgate.config.ts`. Local configs win at each level of the cwd-to-`$HOME` walk, so machine-specific policies layer cleanly on top of team-shared ones without leaving uncommitted changes that block rebasing.
- `toolgate init --project` now also appends `toolgate.config.local.ts` to the project `.gitignore` when run inside a git repo (idempotent; runs even if the shared config already exists, so existing projects can opt in by re-running it).
- Documentation updated in README.md and CLAUDE.md; repo's own `.gitignore` updated.

## Motivation

When you've committed a `toolgate.config.ts` for your team but also want to maintain personal, machine-specific policies on top of it, your only options today are (a) leave uncommitted changes (blocks rebase), or (b) gitignore the file entirely (loses team-shared config). This PR adds a local/shared split following the same convention as Claude Code's `settings.json` / `settings.local.json`.

## Precedence rules

At each directory level (walking cwd up to `$HOME`), in this order:

1. `./toolgate.config.local.ts` (or `./.claude/toolgate.config.local.ts`)
2. `./toolgate.config.ts` (or `./.claude/toolgate.config.ts`)

Built-in policies run last. First non-`next()` verdict wins, so personal policies override shared ones, and inner directories override outer ones.

## Test plan

- [x] `bun test` — all 1024 tests pass
- [x] New tests cover: local-over-shared priority, local-only, `.claude/` fallback for local, and multi-level walk ordering
- [x] Manually verify `toolgate init --project` adds the gitignore entry in a fresh repo
- [x] Manually verify `toolgate list` shows configs in the expected local-before-shared order
