### PR TITLE
fix: treat empty-string deny reason as a reasonless deny

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brycehanscomb/toolgate",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "devDependencies": {
     "bun-types": "latest"
   },

--- a/src/adapter.test.ts
+++ b/src/adapter.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'bun:test'
+import { adaptHandler } from './adapter'
+import { ALLOW, DENY, NEXT } from './verdicts'
+import type { ToolCall } from './types'
+
+const call: ToolCall = {
+  tool: 'Read',
+  args: { file_path: '/foo' },
+  context: { cwd: '/tmp', env: {}, projectRoot: '/tmp' },
+}
+
+describe('adaptHandler', () => {
+  describe('pass-through', () => {
+    for (const [label, value] of [
+      ['undefined', undefined],
+      ['null', null],
+      ['false', false],
+    ] as const) {
+      it(`treats ${label} as next (allow action)`, async () => {
+        const run = adaptHandler('allow', async () => value as any)
+        expect((await run(call)).verdict).toBe(NEXT)
+      })
+      it(`treats ${label} as next (deny action)`, async () => {
+        const run = adaptHandler('deny', async () => value as any)
+        expect((await run(call)).verdict).toBe(NEXT)
+      })
+    }
+  })
+
+  describe('allow action', () => {
+    it('truthy return activates allow', async () => {
+      const run = adaptHandler('allow', async () => true)
+      expect((await run(call)).verdict).toBe(ALLOW)
+    })
+  })
+
+  describe('deny action', () => {
+    it('non-empty string return denies with that reason', async () => {
+      const run = adaptHandler('deny', async () => 'blocked')
+      const result = await run(call)
+      expect(result.verdict).toBe(DENY)
+      if (result.verdict === DENY) expect(result.reason).toBe('blocked')
+    })
+
+    it('true return denies without a reason', async () => {
+      const run = adaptHandler('deny', async () => true)
+      const result = await run(call)
+      expect(result.verdict).toBe(DENY)
+      if (result.verdict === DENY) expect(result.reason).toBeUndefined()
+    })
+
+    it('empty-string return denies without a reason (not an empty reason)', async () => {
+      const run = adaptHandler('deny', async () => '')
+      const result = await run(call)
+      expect(result.verdict).toBe(DENY)
+      if (result.verdict === DENY) expect(result.reason).toBeUndefined()
+    })
+  })
+})

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -18,7 +18,9 @@ export function adaptHandler(
     }
 
     // action === "deny"
-    if (typeof result === "string") {
+    // An empty reason string is treated as a reasonless deny, so the
+    // reason field is consistently undefined when there's no message.
+    if (typeof result === "string" && result.length > 0) {
       return deny(result);
     }
     return deny();


### PR DESCRIPTION
## Summary

Fixes #14 — an `action: "deny"` handler that returns an **empty string** was producing `deny("")` (a deny carrying an empty reason) rather than a reasonless `deny()`.

`""` is a valid `string` per `PolicyHandler` (`Promise<string | boolean | void>`), so it isn't a type error, and it slips past `adaptHandler`'s strict `=== false` pass-through check. It then hit `typeof result === "string" → deny(result)`, setting `reason: ""`.

## Change

`src/adapter.ts` — guard the reason branch on `result.length > 0`:

```ts
if (typeof result === "string" && result.length > 0) {
  return deny(result);
}
return deny();
```

Now the `reason` field is consistently `undefined` when there's no message, instead of an empty string downstream formatting has to special-case.

## Tests

New `src/adapter.test.ts` covering:
- pass-through for `undefined` / `null` / `false` (both actions)
- allow activation on a truthy return
- deny reason cases: non-empty string, `true`, and the empty-string case (would have failed before this fix)

## Verification

- Full suite: **1715 passing**, 0 fail.
- Patch bump to **2.0.1**.

## Out of scope

Numeric returns (`0`, `NaN`) also activate a policy because the check is strict `=== false` rather than general falsiness — but those are only reachable via `as any` (the type forbids them), so left for a separate change as noted in #14.

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)
