### PR TITLE
feat: add `toolgate migrate` codemod for legacy Middleware policies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "@brycehanscomb/toolgate",
       "devDependencies": {
         "bun-types": "latest",
+        "typescript": "^6.0.3",
       },
     },
   },
@@ -13,6 +14,8 @@
     "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
     "bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
+
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
   }

--- a/docs/migration-2.x.md
+++ b/docs/migration-2.x.md
@@ -1,49 +1,66 @@
 # Migrating from toolgate 1.x to 2.x
 
-The 2.0 release **removes the legacy `Middleware` compat shim** that 1.x kept
-for backwards compatibility. The action-based API introduced in 1.0 is now the
-only way to author a policy.
+toolgate 2.0 is a cleanup release. It removes the legacy `Middleware` policy API
+that 1.x kept alive for backwards compatibility, and it prunes a couple of
+built-in policies. Nothing about *how the engine decides* changed — deny still
+runs before allow, first activated verdict still wins. What changed is **how you
+author a policy** and **which built-ins ship in the box**.
 
-If your policies already declare an `action` and return `string | boolean | void`
-(the 1.x style), **you have nothing to do** — 2.0 is a no-op for you. This guide
-is for policies still written in the pre-1.0 `Middleware` style.
+> **Automated path:** run `toolgate migrate` in a project to dry-run the codemod
+> (report only), then `toolgate migrate --write` to apply it. It handles the
+> whole §1 API migration — adds `action`, rewrites `allow()`/`deny()`/`next()`
+> returns, and strips the dead helper imports. It refuses (and reports) any
+> policy that mixes `allow()` and `deny()`, since that needs a human-chosen
+> split (see below). It does **not** cover the §2 built-in changes.
 
-## What was removed
+There are two kinds of change to check for:
+
+1. **API changes** — affect you if any of your policies (or tests) were still
+   written in the pre-1.0 `Middleware` style, or import `allow` / `deny` /
+   `next` / `Middleware` from the package.
+2. **Built-in changes** — affect you if you relied on the built-in `tmux` policy,
+   or referenced the old combined `gh issue/pr` policy by name.
+
+If none of that applies — every policy already declares an `action` and returns
+`string | boolean | void`, and you never touched tmux — **2.0 is a no-op.**
+Bump the dependency and move on.
+
+> **Most readers only need §2.** The action-based API has been the documented
+> way to author policies since 1.0; `Middleware` was only ever a pre-1.0 compat
+> shim. If you adopted toolgate at 1.0 or later, your policies are already
+> action-based and §1 is a no-op — skip to the built-in changes.
+
+---
+
+## 1. API changes
+
+### What was removed
 
 | Removed in 2.0 | Replacement |
 |---|---|
-| Policies without an `action` field | `action: "deny" \| "allow"` is now **required** |
-| `handler` returning a `VerdictResult` (`allow()`/`deny()`/`next()`) | `handler` returns `string \| boolean \| void` |
-| The `Middleware` type (`export`ed from the package) | `PolicyHandler` is the only handler type |
-| Package exports `allow`, `deny`, `next` | Return plain values instead (see below) |
-| The legacy branch in `runPolicy` | Every policy is now adapted through `adaptHandler` |
+| Policies with no `action` field | `action: "deny" \| "allow"` is now **required** |
+| `handler` returning a `VerdictResult` via `allow()` / `deny()` / `next()` | `handler` returns `string \| boolean \| void` |
+| The `Middleware` type export | `PolicyHandler` is the only handler type |
+| The `allow`, `deny`, `next` helper exports | Return plain values (see cheat sheet) |
+| The legacy compat branch in `runPolicy` | Every policy is adapted through `adaptHandler` |
 
-`Policy.handler` is now typed as `PolicyHandler` only. `Policy.action` is now a
-required field, so a policy object without it is a **type error** (and, at
-runtime, would be treated as a deny).
+In 2.0 `Policy.action` is a **required** field and `Policy.handler` is typed as
+`PolicyHandler` only. A policy object missing `action` is now a TypeScript error
+(and at runtime would be treated as a deny).
 
-## Migrating a legacy policy
+### Migrating a legacy policy
 
-**Before (Middleware, still worked in 1.x):**
+The single-action model means one policy expresses **one** decision — it either
+denies or allows, never both. A legacy handler that only ever returned
+`allow()`/`next()` becomes an `action: "allow"` policy; one that only returned
+`deny()`/`next()` becomes `action: "deny"`. Add the `action` field, rewrite the
+returns per the cheat sheet below, and drop the `allow`/`deny`/`next` imports.
 
-```ts
-import { allow, deny, next, type Policy } from "@brycehanscomb/toolgate";
+### Handlers that both allowed *and* denied — split them
 
-const myPolicy: Policy = {
-  name: "Allow X",
-  description: "...",
-  handler: async (call) => {
-    if (call.tool !== "Bash") return next();
-    if (bad(call)) return deny("not allowed");
-    if (ok(call)) return allow();
-    return next();
-  },
-};
-```
-
-**After (2.x):** a policy has a single `action`. If your old handler returned
-**both** `allow()` and `deny()` (like the example above), split it into two
-policies — one `deny`, one `allow`. Deny always runs first, so the split is
+If a single legacy handler returned **both** `allow()` and `deny()`, it can't
+map to one 2.x policy. Split it into a `deny` policy and an `allow` policy.
+Because the engine always runs deny policies before allow policies, the split is
 behaviour-preserving.
 
 ```ts
@@ -55,7 +72,7 @@ const denyX: Policy = {
   action: "deny",
   handler: async (call) => {
     if (call.tool !== "Bash") return;
-    if (bad(call)) return "not allowed"; // string reason → deny
+    if (bad(call)) return "not allowed"; // string reason → deny with message
   },
 };
 
@@ -65,34 +82,48 @@ const allowX: Policy = {
   action: "allow",
   handler: async (call) => {
     if (call.tool !== "Bash") return;
-    if (ok(call)) return true; // truthy → allow
+    if (ok(call)) return true; // allow
   },
 };
 ```
+
+(This is exactly what happened to the built-in `gh issue/pr` policy — see §2.)
 
 ### Return-value cheat sheet
 
 | Old (`Middleware`) | New (`action: "allow"`) | New (`action: "deny"`) |
 |---|---|---|
-| `return allow()` | `return true` | n/a (use an allow policy) |
-| `return deny("reason")` | n/a (use a deny policy) | `return "reason"` |
-| `return deny()` | n/a | `return true` |
-| `return next()` | `return` | `return` |
+| `return allow()` | `return true` | n/a — use an allow policy |
+| `return deny("reason")` | n/a — use a deny policy | `return "reason"` |
+| `return deny()` (no reason) | n/a | `return true` |
+| `return next()` | `return` / `return undefined` | `return` / `return undefined` |
 
-## Imports
+### Imports
 
-`allow`, `deny`, and `next` are **no longer exported** from
-`@brycehanscomb/toolgate`, and neither is the `Middleware` type. Remove those
-imports — policy files typically now import only `type { Policy }` (plus any AST
-helpers from `parse-bash-ast`).
+`allow`, `deny`, `next`, and the `Middleware` type are **no longer exported**
+from `@brycehanscomb/toolgate`. Remove those imports. Most policy files now
+import only `type { Policy }` (plus any AST helpers from `parse-bash-ast`).
 
-Still exported for tests and advanced use: `ALLOW`, `DENY`, `NEXT`,
-`isVerdictResult`, `adaptHandler`, `runPolicy`, `runPolicyWithTrace`,
-`definePolicy`, and the `VerdictResult` / `Policy` / `PolicyHandler` types.
+> **Gotcha:** never delete an import before you've replaced every usage. If a
+> toolgate config has a reference error, evaluation itself fails — which blocks
+> *all* subsequent tool calls, including the ones you'd use to fix it. Replace
+> usages first, then drop the import, or do both in one edit.
 
-## Tests
+Still exported for tests and advanced use:
 
-Test wrapping is unchanged from 1.x — wrap the handler with `adaptHandler`:
+```
+ALLOW, DENY, NEXT, isVerdictResult          // from verdicts
+adaptHandler                                 // wrap a handler → VerdictResult
+definePolicy, runPolicy, runPolicyWithTrace  // engine
+isWithinProject, loadAdditionalDirs          // project-dirs helpers
+type Policy, PolicyHandler, ToolCall,
+     CallContext, VerdictResult, TracedResult
+```
+
+### Tests
+
+Test wrapping is unchanged — wrap the handler with `adaptHandler` and assert on
+the returned `VerdictResult`:
 
 ```ts
 import { adaptHandler, ALLOW, type ToolCall } from "@brycehanscomb/toolgate";
@@ -102,14 +133,63 @@ const result = await run(call);
 expect(result.verdict).toBe(ALLOW);
 ```
 
-(In 1.x you may have written `adaptHandler(policy.action!, policy.handler as any)`
+In 1.x you may have written `adaptHandler(policy.action!, policy.handler as any)`
 to satisfy the optional/union types. With `action` required and `handler`
-narrowed to `PolicyHandler`, the `!` and `as any` are no longer needed.)
+narrowed to `PolicyHandler`, the `!` and `as any` are gone.
+
+---
+
+## 2. Built-in policy changes
+
+These are behavioral breaks that can bite you **even if all your policies
+already use the action API.**
+
+### The `tmux` policy was removed
+
+1.x shipped a built-in "Allow tmux read and send-keys" policy. It's gone in 2.0 —
+tmux was niche for a general-purpose builtin, and `send-keys` in particular
+smuggles an inner command past per-call evaluation.
+
+**Impact:** tmux commands that used to be auto-allowed now **fall through to a
+prompt.** Nothing becomes unsafe; you just get asked. If you want the old
+behaviour back, add it as a project or local policy (`toolgate.config.ts` /
+`toolgate.config.local.ts`).
+
+### The combined `gh issue/pr` policy was split
+
+The old policy both allowed `gh issue`/`gh pr` actions and denied
+`gh issue/pr delete`. The single-action model can't express both, so it became:
+
+- `deny-gh-issue-pr-delete` (`action: "deny"`) — blocks `gh issue/pr delete`
+- `allow-gh-issue-pr` (`action: "allow"`) — permits the rest
+
+Deny runs before allow, so the net decision for any `gh` command is identical to
+1.x. **The only thing that changed is the names.** If you disabled or referenced
+the old combined policy by name (via the `disable` export or `toolgate disable`),
+update the reference to the new name(s).
+
+---
 
 ## Quick checklist
 
+**API:**
+
 1. Add `action: "deny" | "allow"` to every remaining legacy policy.
 2. Split any policy that returned both `allow()` and `deny()` into two policies.
-3. Rewrite handler returns per the cheat sheet above.
+3. Rewrite handler returns per the cheat sheet.
 4. Remove imports of `allow` / `deny` / `next` / `Middleware`.
-5. Run your suite, then `toolgate list` to confirm everything loads.
+
+**Built-ins:**
+
+5. If you relied on the built-in tmux policy, re-add it as a project/local policy.
+6. If you disabled the old combined `gh issue/pr` policy by name, point the
+   disable at `"Deny gh issue/pr delete"` and/or `"Allow gh issue/pr actions"`
+   (the `disable` export matches on a policy's `name` field exactly).
+
+**Verify:**
+
+7. Run your test suite.
+8. Run `toolgate list` to confirm every policy loads, and `toolgate disable --json`
+   to confirm any disable-by-name still resolves.
+</content>
+</invoke>

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
   "name": "@brycehanscomb/toolgate",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "devDependencies": {
-    "bun-types": "latest"
+    "bun-types": "latest",
+    "typescript": "^6.0.3"
   },
   "exports": {
     ".": "./src/index.ts",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -49,6 +49,13 @@ switch (command) {
     await disableCmd(args)
     break
 
+  case 'migrate': {
+    // Lazy import: pulls in typescript, which the run hot path must never load.
+    const { migrateCmd } = await import('./migrate-cmd')
+    await migrateCmd(args)
+    break
+  }
+
   case 'suspend':
     await suspend()
     break
@@ -58,7 +65,7 @@ switch (command) {
     break
 
   default:
-    console.error('Usage: toolgate <run|init|test|list|audit|disable|suspend|logs>')
+    console.error('Usage: toolgate <run|init|test|list|audit|disable|migrate|suspend|logs>')
     console.error('  run              Run policy chain (called by hooks)')
     console.error('  init             Register PreToolUse hook')
     console.error('  init --project   Set up project config')
@@ -71,6 +78,8 @@ switch (command) {
     console.error('    --local        Target toolgate.config.local.ts (create in cwd if missing)')
     console.error('    --file=<path>  Target a specific config file (create if missing)')
     console.error('    --json         Dump all policies + disable state as JSON')
+    console.error('  migrate [paths]  Codemod legacy Middleware policies to the 2.x action API')
+    console.error('    --write        Apply changes (default: dry-run report)')
     console.error('  suspend          Suspend all policies (Ctrl+C to resume)')
     console.error('  logs             Show Claude Code log file locations')
     process.exit(1)

--- a/src/migrate-cmd.ts
+++ b/src/migrate-cmd.ts
@@ -1,0 +1,83 @@
+/**
+ * `toolgate migrate` — codemod for legacy Middleware-style policy configs.
+ *
+ * Defaults to a dry run (report only). Pass --write to apply changes.
+ * This module pulls in `typescript`, so cli.ts imports it lazily — the `run`
+ * hot path never loads it.
+ */
+import { readFile, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { migrateSource, type MigrateResult } from "./migrate";
+
+const DEFAULT_TARGETS = ["toolgate.config.ts", "toolgate.config.local.ts"];
+
+export async function migrateCmd(args: string[]): Promise<void> {
+  const write = args.includes("--write");
+  const paths = args.filter((a) => !a.startsWith("--"));
+  const targets = paths.length > 0 ? paths : DEFAULT_TARGETS;
+
+  let anyChanged = false;
+  let anySkipped = false;
+  let processed = 0;
+
+  for (const target of targets) {
+    const abs = resolve(process.cwd(), target);
+    let code: string;
+    try {
+      code = await readFile(abs, "utf-8");
+    } catch {
+      // Only complain about explicitly-named files; skip absent defaults.
+      if (paths.length > 0) console.error(`  ✗ ${target}: not found`);
+      continue;
+    }
+    processed++;
+
+    const result = migrateSource(code);
+    report(target, result);
+
+    if (result.status === "migrated") {
+      anyChanged = true;
+      if (write) {
+        await writeFile(abs, result.code, "utf-8");
+        console.log(`  ✎ wrote ${target}`);
+      }
+    }
+    if (result.status === "skipped") anySkipped = true;
+  }
+
+  if (processed === 0) {
+    console.error(
+      "No config files found. Pass a path, or run from a directory with " +
+        "toolgate.config.ts.",
+    );
+    process.exit(1);
+  }
+
+  if (!write && anyChanged) {
+    console.log("\nDry run — re-run with --write to apply.");
+  }
+  if (anySkipped) process.exit(2);
+}
+
+function report(target: string, r: MigrateResult): void {
+  const badge =
+    r.status === "migrated" ? "→" : r.status === "skipped" ? "⚠" : "·";
+  console.log(`\n${badge} ${target}`);
+
+  if (r.status === "unchanged" && r.policies.length === 0) {
+    console.log("  already action-based (or no legacy policies) — nothing to do");
+  }
+
+  if (r.removedImports.length > 0) {
+    console.log(`  imports: drop ${r.removedImports.join(", ")}`);
+  }
+
+  for (const p of r.policies) {
+    const mark = p.action ? "  •" : "  ⚠";
+    console.log(`${mark} ${p.name}: ${p.detail}`);
+  }
+
+  for (const w of r.warnings) {
+    console.log(`  ⚠ ${w}`);
+  }
+}

--- a/src/migrate.test.ts
+++ b/src/migrate.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from "bun:test";
+import { migrateSource } from "./migrate";
+
+describe("migrateSource", () => {
+  it("migrates an allow-only policy: adds action, rewrites returns, drops imports", () => {
+    const src = `import { definePolicy, allow, next } from "toolgate";
+
+export default definePolicy([
+  {
+    name: "Allow Read",
+    description: "Permits Read",
+    handler: async (call) => call.tool === "Read" ? allow() : next(),
+  },
+]);
+`;
+    const r = migrateSource(src);
+    expect(r.status).toBe("migrated");
+    expect(r.removedImports).toEqual(["allow", "next"]);
+    expect(r.code).toContain('import { definePolicy } from "toolgate"');
+    expect(r.code).toContain('action: "allow"');
+    expect(r.code).toContain("call.tool === \"Read\" ? true : undefined");
+    expect(r.code).not.toMatch(/\ballow\(\)/);
+    expect(r.code).not.toMatch(/\bnext\(\)/);
+    expect(r.policies).toHaveLength(1);
+    expect(r.policies[0]).toMatchObject({ name: "Allow Read", action: "allow" });
+  });
+
+  it("migrates a deny-only policy: deny(msg) → msg, deny() → true", () => {
+    const src = `import { definePolicy, deny, next } from "toolgate";
+
+export default definePolicy([
+  {
+    name: "Deny rm",
+    description: "Blocks rm",
+    handler: async (call) => {
+      if (call.tool !== "Bash") return next();
+      if (call.args.command === "rm -rf /") return deny("nope");
+      if (call.args.command.startsWith("rm")) return deny();
+      return next();
+    },
+  },
+]);
+`;
+    const r = migrateSource(src);
+    expect(r.status).toBe("migrated");
+    expect(r.code).toContain('action: "deny"');
+    expect(r.code).toContain('return "nope"');
+    expect(r.code).toContain("return true"); // deny() → true
+    expect(r.code).toContain("return undefined"); // next() → undefined
+    expect(r.policies[0].action).toBe("deny");
+  });
+
+  it("skips (writes nothing) a policy that mixes allow() and deny()", () => {
+    const src = `import { definePolicy, allow, deny, next } from "toolgate";
+
+export default definePolicy([
+  {
+    name: "Mixed",
+    description: "both",
+    handler: async (call) => {
+      if (bad(call)) return deny("no");
+      if (ok(call)) return allow();
+      return next();
+    },
+  },
+]);
+`;
+    const r = migrateSource(src);
+    expect(r.status).toBe("skipped");
+    expect(r.code).toBe(src); // untouched
+    expect(r.policies[0].action).toBeNull();
+    expect(r.warnings.join(" ")).toContain("mix allow() and deny()");
+  });
+
+  it("still migrates other policies' analysis but writes nothing when any is mixed", () => {
+    const src = `import { definePolicy, allow, deny, next } from "toolgate";
+
+export default definePolicy([
+  { name: "Fine", description: "", handler: async (c) => allow() },
+  { name: "Mixed", description: "", handler: async (c) => bad(c) ? deny("x") : allow() },
+]);
+`;
+    const r = migrateSource(src);
+    expect(r.status).toBe("skipped");
+    expect(r.code).toBe(src);
+  });
+
+  it("strips dead helper imports from an empty config", () => {
+    const src = `import { definePolicy, allow, deny, next } from "toolgate";
+
+export default definePolicy([]);
+`;
+    const r = migrateSource(src);
+    expect(r.status).toBe("migrated");
+    expect(r.removedImports).toEqual(["allow", "deny", "next"]);
+    expect(r.code).toContain('import { definePolicy } from "toolgate"');
+    expect(r.policies).toHaveLength(0);
+  });
+
+  it("removes the whole import line when only legacy helpers were imported", () => {
+    const src = `import { definePolicy } from "toolgate";
+import { allow, next } from "toolgate";
+
+export default definePolicy([
+  { name: "A", description: "", handler: async (c) => allow() },
+]);
+`;
+    const r = migrateSource(src);
+    expect(r.status).toBe("migrated");
+    expect(r.code).not.toContain('import { allow, next }');
+    expect(r.code).toContain('import { definePolicy } from "toolgate"');
+  });
+
+  it("is a no-op for already-migrated configs", () => {
+    const src = `import { definePolicy } from "toolgate";
+
+export default definePolicy([
+  {
+    name: "Allow Read",
+    description: "",
+    action: "allow",
+    handler: async (call) => call.tool === "Read" ? true : undefined,
+  },
+]);
+`;
+    const r = migrateSource(src);
+    expect(r.status).toBe("unchanged");
+    expect(r.code).toBe(src);
+  });
+
+  it("respects import aliases", () => {
+    const src = `import { definePolicy, allow as ok, next as skip } from "toolgate";
+
+export default definePolicy([
+  { name: "A", description: "", handler: async (c) => c.tool === "Read" ? ok() : skip() },
+]);
+`;
+    const r = migrateSource(src);
+    expect(r.status).toBe("migrated");
+    expect(r.code).toContain('c.tool === "Read" ? true : undefined');
+    expect(r.code).toContain('import { definePolicy } from "toolgate"');
+  });
+
+  it("skips a file that uses a legacy helper outside a direct call", () => {
+    const src = `import { definePolicy, allow, next } from "toolgate";
+
+const fallback = next;
+export default definePolicy([
+  { name: "A", description: "", handler: async (c) => allow() },
+]);
+`;
+    const r = migrateSource(src);
+    expect(r.status).toBe("skipped");
+    expect(r.code).toBe(src);
+    expect(r.warnings.join(" ")).toContain("outside a direct call");
+  });
+
+  it("does not touch helpers imported from an unrelated module", () => {
+    const src = `import { definePolicy } from "toolgate";
+import { allow } from "some-other-lib";
+
+export default definePolicy([
+  { name: "A", description: "", action: "allow", handler: async (c) => true },
+]);
+`;
+    const r = migrateSource(src);
+    expect(r.status).toBe("unchanged");
+    expect(r.removedImports).toEqual([]);
+    expect(r.code).toBe(src);
+  });
+
+  it("defaults a next()-only policy to allow with a warning", () => {
+    const src = `import { definePolicy, next } from "toolgate";
+
+export default definePolicy([
+  { name: "Inert", description: "", handler: async (c) => next() },
+]);
+`;
+    const r = migrateSource(src);
+    expect(r.status).toBe("migrated");
+    expect(r.policies[0].action).toBe("allow");
+    expect(r.warnings.join(" ")).toContain("never activates");
+  });
+});

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -1,0 +1,351 @@
+/**
+ * Codemod: migrate legacy Middleware-style toolgate policies to the 2.x
+ * action-based API.
+ *
+ * Legacy policies (pre-1.0) have no `action` field and return `allow()` /
+ * `deny()` / `next()` helper calls. 2.x requires an `action` and returns plain
+ * `string | boolean | void`. This transform:
+ *
+ *   - anchors on the module `definePolicy` is imported from, and treats the
+ *     `allow` / `deny` / `next` bindings from that same module as legacy helpers
+ *     (respecting aliases);
+ *   - infers each policy's `action` from which helpers its handler calls;
+ *   - rewrites `allow()`→`true`, `deny(x)`→`x`, `deny()`→`true`, `next()`→`undefined`;
+ *   - inserts the `action` property;
+ *   - strips the now-dead helper imports.
+ *
+ * Changes are applied as position-based text splices so existing formatting is
+ * preserved (the file is parsed, never reprinted).
+ *
+ * A policy whose handler calls BOTH allow() and deny() can't map to one
+ * action — it must be split into two policies with distinct names, which needs
+ * a human. Such a file is reported and left untouched (nothing is written).
+ */
+import ts from "typescript";
+
+export type MigrateStatus = "migrated" | "unchanged" | "skipped";
+
+export interface PolicyChange {
+  /** The policy's `name` value, if a string literal; else a positional label. */
+  name: string;
+  /** Inferred action, or null when the policy was skipped. */
+  action: "allow" | "deny" | null;
+  /** Human-readable summary of the rewrites applied to this policy. */
+  detail: string;
+}
+
+export interface MigrateResult {
+  status: MigrateStatus;
+  /** The transformed source (equals input when status !== "migrated"). */
+  code: string;
+  /** Per-policy report. */
+  policies: PolicyChange[];
+  /** Import specifiers removed (e.g. ["allow", "next"]). */
+  removedImports: string[];
+  /** Non-fatal notes and the reasons a file was skipped. */
+  warnings: string[];
+}
+
+type HelperKind = "allow" | "deny" | "next";
+
+interface Splice {
+  start: number;
+  end: number;
+  text: string;
+}
+
+const LEGACY_NAMES: HelperKind[] = ["allow", "deny", "next"];
+
+/**
+ * Transform a single config file's source. Pure — no filesystem access.
+ */
+export function migrateSource(code: string): MigrateResult {
+  const sf = ts.createSourceFile(
+    "config.ts",
+    code,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    ts.ScriptKind.TS,
+  );
+
+  const result: MigrateResult = {
+    status: "unchanged",
+    code,
+    policies: [],
+    removedImports: [],
+    warnings: [],
+  };
+
+  // --- 1. Find where `definePolicy` is imported from, and map legacy helper
+  //        local names → kind, restricted to those same module specifiers. ---
+  const definePolicyModules = new Set<string>();
+  for (const stmt of sf.statements) {
+    if (!ts.isImportDeclaration(stmt)) continue;
+    const named = stmt.importClause?.namedBindings;
+    if (!named || !ts.isNamedImports(named)) continue;
+    const spec = (stmt.moduleSpecifier as ts.StringLiteral).text;
+    for (const el of named.elements) {
+      if ((el.propertyName ?? el.name).text === "definePolicy") {
+        definePolicyModules.add(spec);
+      }
+    }
+  }
+
+  // local name → helper kind
+  const helperLocals = new Map<string, HelperKind>();
+  // import declarations that need specifier surgery
+  const importEdits: Splice[] = [];
+
+  for (const stmt of sf.statements) {
+    if (!ts.isImportDeclaration(stmt)) continue;
+    const clause = stmt.importClause;
+    const named = clause?.namedBindings;
+    if (!named || !ts.isNamedImports(named)) continue;
+    const spec = (stmt.moduleSpecifier as ts.StringLiteral).text;
+    if (!definePolicyModules.has(spec)) continue;
+
+    const kept: string[] = [];
+    const removed: string[] = [];
+    for (const el of named.elements) {
+      const imported = (el.propertyName ?? el.name).text as HelperKind;
+      if (LEGACY_NAMES.includes(imported)) {
+        helperLocals.set(el.name.text, imported);
+        removed.push(el.getText(sf));
+      } else {
+        kept.push(el.getText(sf));
+      }
+    }
+    if (removed.length === 0) continue;
+    result.removedImports.push(...removed);
+
+    if (kept.length === 0 && !clause.name) {
+      // Whole import becomes dead — remove the statement and its line break.
+      let end = stmt.end;
+      while (end < code.length && code[end] !== "\n") end++;
+      if (code[end] === "\n") end++;
+      importEdits.push({ start: stmt.getStart(sf), end, text: "" });
+    } else {
+      // Rewrite just the `{ ... }` named-imports list.
+      importEdits.push({
+        start: named.getStart(sf),
+        end: named.end,
+        text: `{ ${kept.join(", ")} }`,
+      });
+    }
+  }
+
+  if (helperLocals.size === 0) {
+    // No legacy helpers in play. Either already migrated or not a policy file.
+    return result;
+  }
+
+  // --- 2. Guard: every reference to a legacy local name must be the callee of
+  //        a call expression we can rewrite. A bare reference (passed as a
+  //        value, aliased at runtime, etc.) means we can't safely transform. ---
+  const badRefs: string[] = [];
+  const collectBadRefs = (node: ts.Node) => {
+    if (
+      ts.isIdentifier(node) &&
+      helperLocals.has(node.text) &&
+      !isImportSpecifierName(node)
+    ) {
+      const parent = node.parent;
+      const isCallee =
+        parent && ts.isCallExpression(parent) && parent.expression === node;
+      if (!isCallee) badRefs.push(node.text);
+    }
+    ts.forEachChild(node, collectBadRefs);
+  };
+  collectBadRefs(sf);
+  if (badRefs.length > 0) {
+    result.status = "skipped";
+    result.warnings.push(
+      `Legacy helper(s) ${uniq(badRefs).join(", ")} are used outside a direct call ` +
+        `(e.g. passed as a value). Migrate this file by hand.`,
+    );
+    return result;
+  }
+
+  // --- 3. Locate the definePolicy([...]) array and iterate policy objects. ---
+  const policyObjects: ts.ObjectLiteralExpression[] = [];
+  const findPolicies = (node: ts.Node) => {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === "definePolicy" &&
+      node.arguments.length > 0 &&
+      ts.isArrayLiteralExpression(node.arguments[0])
+    ) {
+      for (const el of node.arguments[0].elements) {
+        if (ts.isObjectLiteralExpression(el)) policyObjects.push(el);
+      }
+    }
+    ts.forEachChild(node, findPolicies);
+  };
+  findPolicies(sf);
+
+  const bodyEdits: Splice[] = [];
+  let mixedFound = false;
+
+  for (const obj of policyObjects) {
+    const nameProp = getProp(obj, "name");
+    const label =
+      nameProp && ts.isStringLiteralLike(nameProp.initializer)
+        ? nameProp.initializer.text
+        : `(policy at ${lineOf(sf, obj)})`;
+
+    // Already action-based? Leave it alone.
+    if (getProp(obj, "action")) {
+      continue;
+    }
+
+    const handler = getProp(obj, "handler");
+    if (!handler) continue;
+
+    // Gather helper calls inside the handler.
+    const calls: { node: ts.CallExpression; kind: HelperKind }[] = [];
+    const scan = (node: ts.Node) => {
+      if (ts.isCallExpression(node) && ts.isIdentifier(node.expression)) {
+        const kind = helperLocals.get(node.expression.text);
+        if (kind) calls.push({ node, kind });
+      }
+      ts.forEachChild(node, scan);
+    };
+    scan(handler.initializer);
+
+    const hasAllow = calls.some((c) => c.kind === "allow");
+    const hasDeny = calls.some((c) => c.kind === "deny");
+
+    if (hasAllow && hasDeny) {
+      mixedFound = true;
+      result.policies.push({
+        name: label,
+        action: null,
+        detail:
+          "MIXED allow() + deny() — split into a deny policy and an allow " +
+          "policy (deny runs first, so the split is behaviour-preserving). Manual.",
+      });
+      continue;
+    }
+
+    const action: "allow" | "deny" = hasDeny ? "deny" : "allow";
+    if (!hasAllow && !hasDeny) {
+      result.warnings.push(
+        `Policy "${label}" never returns allow()/deny() — defaulting to ` +
+          `action: "allow" (it never activates either way).`,
+      );
+    }
+
+    // Rewrite each helper call.
+    let rewrites = 0;
+    for (const { node, kind } of calls) {
+      bodyEdits.push({
+        start: node.getStart(sf),
+        end: node.end,
+        text: replacementFor(kind, node, sf),
+      });
+      rewrites++;
+    }
+
+    // Insert the action property after `description` (else `name`, else first).
+    const anchor =
+      getProp(obj, "description") ??
+      nameProp ??
+      (obj.properties.length > 0 ? obj.properties[0] : undefined);
+    if (anchor) {
+      const indent = indentOf(code, anchor.getStart(sf));
+      bodyEdits.push({
+        start: anchor.end,
+        end: anchor.end,
+        text: `,\n${indent}action: "${action}"`,
+      });
+    }
+
+    result.policies.push({
+      name: label,
+      action,
+      detail: `action: "${action}"; ${rewrites} return${rewrites === 1 ? "" : "s"} rewritten`,
+    });
+  }
+
+  if (mixedFound) {
+    result.status = "skipped";
+    result.warnings.push(
+      "File contains policies that mix allow() and deny(); nothing was written. " +
+        "Split those policies by hand, then re-run.",
+    );
+    return result;
+  }
+
+  const edits = [...importEdits, ...bodyEdits];
+  if (edits.length === 0) {
+    return result;
+  }
+
+  result.code = applySplices(code, edits);
+  result.status = "migrated";
+  return result;
+}
+
+// --- helpers ---------------------------------------------------------------
+
+function replacementFor(
+  kind: HelperKind,
+  node: ts.CallExpression,
+  sf: ts.SourceFile,
+): string {
+  if (kind === "allow") return "true";
+  if (kind === "next") return "undefined";
+  // deny
+  if (node.arguments.length === 0) return "true";
+  return node.arguments[0].getText(sf);
+}
+
+function getProp(
+  obj: ts.ObjectLiteralExpression,
+  name: string,
+): ts.PropertyAssignment | undefined {
+  for (const p of obj.properties) {
+    if (
+      ts.isPropertyAssignment(p) &&
+      (ts.isIdentifier(p.name) || ts.isStringLiteralLike(p.name)) &&
+      p.name.text === name
+    ) {
+      return p;
+    }
+  }
+  return undefined;
+}
+
+function isImportSpecifierName(node: ts.Identifier): boolean {
+  const p = node.parent;
+  return !!p && ts.isImportSpecifier(p);
+}
+
+/** Leading whitespace of the line containing `pos`. */
+function indentOf(code: string, pos: number): string {
+  let start = pos;
+  while (start > 0 && code[start - 1] !== "\n") start--;
+  let i = start;
+  while (i < code.length && (code[i] === " " || code[i] === "\t")) i++;
+  return code.slice(start, i);
+}
+
+function lineOf(sf: ts.SourceFile, node: ts.Node): string {
+  const { line } = sf.getLineAndCharacterOfPosition(node.getStart(sf));
+  return `line ${line + 1}`;
+}
+
+function uniq(xs: string[]): string[] {
+  return [...new Set(xs)];
+}
+
+/** Apply non-overlapping splices, right-to-left so offsets stay valid. */
+function applySplices(code: string, edits: Splice[]): string {
+  const sorted = [...edits].sort((a, b) => b.start - a.start);
+  let out = code;
+  for (const e of sorted) {
+    out = out.slice(0, e.start) + e.text + out.slice(e.end);
+  }
+  return out;
+}


### PR DESCRIPTION
## What

Adds `toolgate migrate` — a codemod that migrates legacy Middleware-style policy
configs (pre-1.0: no `action`, handlers returning `allow()`/`deny()`/`next()`) to
the 2.x action-based API.

## Why

A Middleware-style config hard-breaks on upgrade to 2.0: the removed `allow`/`deny`/`next`
helper imports no longer resolve, and an unresolved config import fails toolgate
evaluation — which blocks *all* subsequent tool calls. So the failure mode on
upgrade isn't graceful degradation, it's a locked session until the file is fixed
by hand. This gives users a one-command fix.

The migration is safe on the version axis: the action-based, `string | boolean | void`
shape it produces has been native to the entire 1.x line (via `adaptHandler`), so a
migrated config loads under both 1.x and 2.x — it broadens compatibility rather than
narrowing it.

## How

- **`src/migrate.ts`** — pure `migrateSource(code)` using the TypeScript compiler
  API to parse, then **position-based text splicing** to apply edits so existing
  formatting is preserved (the file is parsed, never reprinted). It:
  - anchors on the module `definePolicy` is imported from and treats `allow`/`deny`/`next`
    from that same module as legacy helpers (handles varying import specifiers + aliases);
  - infers each policy's `action` from which helpers its handler calls;
  - rewrites `allow()`→`true`, `deny(x)`→`x`, `deny()`→`true`, `next()`→`undefined`;
  - inserts the `action` property and strips the dead helper imports;
  - **refuses to write** any file with a policy that mixes `allow()`+`deny()` (needs a
    human-chosen split into a deny + an allow policy), or a helper used outside a
    direct call — reporting these instead.
- **`src/migrate-cmd.ts`** + `cli.ts` — `toolgate migrate [paths]` (dry-run report by
  default), `--write` to apply. Lazy-imported so `typescript` never loads on the `run`
  hot path. Exit code 2 when any file is skipped.
- **`src/migrate.test.ts`** — 11 cases: allow-only, deny-only, mixed→skip, dead-imports-only,
  already-migrated no-op, whole-import removal, aliases, non-call reference→skip,
  unrelated-module helper ignored, inert `next()`-only default.
- Adds `typescript` as a **devDependency**; `docs/migration-2.x.md` points at the command.
- Bumps version to **2.1.0** (new feature).

## Testing

- Full suite green (1726 pass, 0 fail).
- Dry-run + `--write` validated against two real-world configs: a 15-policy config
  (all allow-only, 0 splits) and an empty-but-dead-imports config. Both syntax-check
  (`bun build`, exit 0) and load through the engine with every policy carrying a
  valid `action`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
