### PR TITLE
ci: add bun test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run tests
+        run: bun test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,13 @@ jobs:
         with:
           bun-version: latest
 
+      - name: Install shfmt
+        run: |
+          curl -fsSL -o /usr/local/bin/shfmt \
+            https://github.com/mvdan/sh/releases/download/v3.13.1/shfmt_v3.13.1_linux_amd64
+          chmod +x /usr/local/bin/shfmt
+          shfmt --version
+
       - name: Install dependencies
         run: bun install --frozen-lockfile
 


### PR DESCRIPTION
## What

Adds a GitHub Actions workflow that runs `bun test` on every PR and push to `main`.

## Why

To gate merges on a green test suite as part of branch protection.

## Details

- Uses `oven-sh/setup-bun@v2`
- `bun install --frozen-lockfile` for reproducible installs
- Runs the full `bun test` suite

Once this merges and the `test` check has reported at least once, it will be wired up as a required status check on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
