### PR TITLE
docs: document GitHub clone as the install method

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,16 @@ go install mvdan.cc/sh/v3/cmd/shfmt@latest
 
 ### Package
 
+Install by cloning the repository and linking a local checkout:
+
 ```bash
-bun install -g @brycehanscomb/toolgate
+git clone git@github.com:brycehans/toolgate.git
+cd toolgate
+bun install
+bun link
 ```
+
+`bun link` puts the `toolgate` executable on your PATH via the `bin` field in `package.json`.
 
 ## Setup
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brycehanscomb/toolgate",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "devDependencies": {
     "bun-types": "latest",
     "typescript": "^6.0.3"


### PR DESCRIPTION
## Problem

The README told users to install with:

```bash
bun install -g @brycehanscomb/toolgate
```

That package isn't published to any registry, so the command fails with a not-found error for anyone following the README.

## Fix

Document the actual supported installation method — cloning the repo and linking a local checkout:

```bash
git clone git@github.com:brycehans/toolgate.git
cd toolgate
bun install
bun link
```

Also bumps the version to `2.3.1` per the repo's push-requires-a-bump convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
